### PR TITLE
Keep full defense if already less than 10

### DIFF
--- a/src/module/actor/actor.js
+++ b/src/module/actor/actor.js
@@ -265,7 +265,7 @@ export class ICRPGActor extends Actor {
     else if (this.type === 'monster') mod += attribute + this.system[group].all + this.system.allRollsMod;
 
     // Only exception to mod: defense
-    if (name === 'defense') mod -= 10;
+    if (name === 'defense' && mod >= 10) mod -= 10;
 
     // Do the roll
     let formula = `@dice ${plusifyMod(mod)}`;


### PR DESCRIPTION
Most monsters, certainly those included in the premium content, have a straight modifier to all stats. This typically means if you roll defense from the roll selector, you end up with a negative modifier as the attribute is already the modifier. This fix is a simple one, it may be better to check that the actor is a monster as well, but this may be sufficient.