### PR TITLE
Enrich item descriptions to support @UUID links

### DIFF
--- a/src/module/applications/item/item-sheet-v2.js
+++ b/src/module/applications/item/item-sheet-v2.js
@@ -2,6 +2,7 @@ import ICRPGSheetMixin from '../icrpg-sheet-mixin.js';
 
 const { HandlebarsApplicationMixin } = foundry.applications.api;
 const { ItemSheetV2 } = foundry.applications.sheets;
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
 
 export default class ICRPGItemSheetV2 extends ICRPGSheetMixin(HandlebarsApplicationMixin(ItemSheetV2)) {
   static DEFAULT_OPTIONS = {
@@ -34,6 +35,14 @@ export default class ICRPGItemSheetV2 extends ICRPGSheetMixin(HandlebarsApplicat
 
   static PARTS_NON_EDITABLE = ['bonuses', 'tabNavigation'];
   static PARTS_NON_VISIBLE = ['description'];
+
+  async _prepareContext(options) {
+    const context = await super._prepareContext(options);
+    if (context.system?.description) {
+      context.system.enrichedDescription = await TextEditor.enrichHTML(context.system.description, { async: true });
+    }
+    return context;
+  }
 
   static TABS = {
     primary: {

--- a/src/module/applications/item/item-sheet.js
+++ b/src/module/applications/item/item-sheet.js
@@ -1,5 +1,6 @@
 import { i18n, onArrayEdit } from '../../utils/utils.js';
 const { ItemSheet } = foundry.appv1.sheets;
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
 
 export class ICRPGItemSheet extends ItemSheet {
   static get defaultOptions() {
@@ -28,6 +29,7 @@ export class ICRPGItemSheet extends ItemSheet {
     let content = super.getData();
     content.system = this.item.system;
     content.isLocked = this.isLocked ?? true;
+    content.system.enrichedDescription = await TextEditor.enrichHTML(this.item.system.description, { async: true });
     return content;
   }
 

--- a/src/templates/item/generic-item.hbs
+++ b/src/templates/item/generic-item.hbs
@@ -156,7 +156,7 @@
 
 {{#* inline "description"}}
   {{#if isLocked}}
-    <div class="item-description">{{system.description}}</div>
+    <div class="item-description">{{{system.enrichedDescription}}}</div>
   {{else}}
     <textarea name="system.description" autosize spellcheck="false"
               placeholder="{{localize "Description"}}">{{system.description}}</textarea>

--- a/src/templates/item/parts/item-description.hbs
+++ b/src/templates/item/parts/item-description.hbs
@@ -3,6 +3,6 @@
     <textarea name="system.description" autosize spellcheck="false" class="description-text"
               placeholder="{{localize "Description"}}">{{system.description}}</textarea>
   {{else}}
-    <div class="description-text">{{system.description}}</div>
+    <div class="description-text">{{{system.enrichedDescription}}}</div>
   {{/if}}
 </section>

--- a/src/templates/item/parts/power-description.hbs
+++ b/src/templates/item/parts/power-description.hbs
@@ -21,7 +21,7 @@
     </div>
 
   {{else}}
-    <div class="description-text">{{system.description}}</div>
+    <div class="description-text">{{{system.enrichedDescription}}}</div>
     {{#each system.spCosts as |entry index|}}
       <div class="power-cost" data-entry-index="{{index}}">
         <b>{{localize "ICRPG.spCost"}} {{entry.cost}}:</b>

--- a/src/templates/item/parts/spell-description.hbs
+++ b/src/templates/item/parts/spell-description.hbs
@@ -44,7 +44,7 @@
     </div>
 
   {{else}}
-    <div class="description-text">{{system.description}}</div>
+    <div class="description-text">{{{system.enrichedDescription}}}</div>
     {{#if system.target}}
       <div class="tt-u mt-12"><b>{{localize "ICRPG.spell.target"}}: {{system.target}}</b></div>
     {{/if}}


### PR DESCRIPTION
### Summary
- Item descriptions now render @UUID links (and other enriched HTML) instead of displaying them as raw text
- Uses TextEditor.enrichHTML() in both V1 and V2 item sheets to process descriptions before rendering
- Templates use triple-brace {{{enrichedDescription}}} in view mode so enriched HTML renders correctly. Edit mode textareas are unchanged

### How to Test
 1. Open an item sheet with @UUID[...] syntax in the description — verify it renders as a clickable link in locked/view mode
 2. Unlock the sheet and verify the raw @UUID text is still editable in the textarea
 3. Test across item types: loot, ability, power, spell, augment, hard suit part